### PR TITLE
set learning/.* to interactive to prevent parallel cloning

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -8,7 +8,7 @@ version_control:
     - learning/.*:
         github: rock-learning/bolero.git
         branch: master
+        interactive: true
     - tools/catch:
       type: git
       url: https://github.com/philsquared/Catch
-


### PR DESCRIPTION
This PR sets the learning packages to interactive. This prevents autoproj from cloning sub projects in parallel. Parallel cloning does not work for learning/bolero because the project consists of several "fake" projects (i.e. several sub projects of bolero share the same git repo). Parallel cloning of fake projects leads to locking errors because multiple instances of git try to access .git/config at the same time.

This is the same workaround that was used in mars.