### PR TITLE
Let rock.core do the python setup

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,0 @@
-python_version = %x{python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'}[0..2]
-Autobuild.env_add_path(
-    'PYTHONPATH',
-    '${AUTOPROJ_CURRENT_ROOT}/install/lib/python' + python_version + '/site-packages/'
-)

--- a/source.yml
+++ b/source.yml
@@ -1,6 +1,8 @@
 name: rock.learning
 
 imports:
+    # for basic setup and osdeps definitions
+    - github: rock-core/package_set
     # includes helping libraries
     - github: rock-simulation/package_set
 


### PR DESCRIPTION
rock.core package_set handles now the python setup, allowing users to choose the python version via an autoproj configuration option. 
There be nothing to do except to import rock.core in the source.yml.

To update/fix the corresponding functionality in rock.core if needed
see https://github.com/rock-core/package_set/blob/master/rock/python.rb